### PR TITLE
remove uri encoding

### DIFF
--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -84,9 +84,6 @@ class RequestHandler {
                         headers.Authorization = this._client.token;
                     }
                     if(body && body.reason) { // Audit log reason sniping
-                        if(body.reason === decodeURI(body.reason)) {
-                            body.reason = encodeURIComponent(body.reason);
-                        }
                         headers["X-Audit-Log-Reason"] = body.reason;
                         delete body.reason;
                     }


### PR DESCRIPTION
The X-Audit-Log-Reason header accepts all utf8 characters, as specified here: https://discordapp.com/developers/docs/resources/audit-log